### PR TITLE
Add Storage API persistence to protect calendar data

### DIFF
--- a/src/contexts/CalendarContext.tsx
+++ b/src/contexts/CalendarContext.tsx
@@ -70,6 +70,32 @@ export const CalendarProvider: React.FC<CalendarProviderProps> = ({ children }) 
     }
   }, [currentYear])
 
+  useEffect(() => {
+    const requestPersistentStorage = async () => {
+      if (navigator.storage && navigator.storage.persist) {
+        try {
+          const isPersisted = await navigator.storage.persisted()
+          if (isPersisted) {
+            console.log("Storage is already persistent")
+          } else {
+            const granted = await navigator.storage.persist()
+            if (granted) {
+              console.log("Persistent storage granted")
+            } else {
+              console.log("Persistent storage denied")
+            }
+          }
+        } catch (error) {
+          console.error("Error requesting persistent storage:", error)
+        }
+      } else {
+        console.log("Storage API not supported in this browser")
+      }
+    }
+
+    void requestPersistentStorage()
+  }, [])
+
   const saveToLocalStorage = (data: StoredData) => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(data))


### PR DESCRIPTION
## Add Storage API persistence to protect calendar data

### Summary
Requests persistent storage using [navigator.storage.persist()](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist) to reduce the risk of browsers automatically clearing user calendar data.

### Changes
- Added `useEffect` hook in `CalendarContext.tsx` to request persistent storage on app load
- Logs persistence status to console for debugging
- Gracefully handles browsers that don't support the Storage API

### Benefits
- Browser is less likely to evict localStorage data under storage pressure

### Notes
Browsers typically grant persistence based on user engagement (bookmarking, frequent visits, PWA installation). The app continues to work normally whether persistence is granted or denied.